### PR TITLE
Refactor test configuration and update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pytest-infrahouse ~= 0.9, >= 0.9.2
-infrahouse-core ~= 0.14
+pytest-infrahouse ~= 0.17, >= 0.17.1
+infrahouse-core ~= 0.17

--- a/test_data/sql-ecs/locals.tf
+++ b/test_data/sql-ecs/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  service_name = "sqs-test-${random_string.suffix.result}"
+}

--- a/test_data/sql-ecs/main.tf
+++ b/test_data/sql-ecs/main.tf
@@ -2,9 +2,10 @@ resource "random_string" "suffix" {
   length  = 6
   special = false
 }
+
 module "test" {
   source                   = "./../../"
-  service_name             = "sqs-test-${random_string.suffix.result}"
+  service_name             = local.service_name
   consumer_subnet_ids      = var.consumer_subnet_ids
   consumer_docker_image    = "httpd"
   consumer_asg_max_size    = 1

--- a/test_data/sql-ecs/outputs.tf
+++ b/test_data/sql-ecs/outputs.tf
@@ -1,0 +1,4 @@
+output "service_name" {
+  description = "Name of the ECS service"
+  value       = local.service_name
+}

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -11,10 +11,7 @@ from tests.conftest import (
 
 
 def test_module(
-    service_network,
-    test_role_arn,
-    keep_after,
-    aws_region,
+    service_network, test_role_arn, keep_after, aws_region, cleanup_ecs_task_definitions
 ):
     subnet_private_ids = service_network["subnet_private_ids"]["value"]
 
@@ -43,3 +40,4 @@ def test_module(
         json_output=True,
     ) as tf_output:
         LOG.info("%s", json.dumps(tf_output, indent=4))
+        cleanup_ecs_task_definitions(tf_output["service_name"]["value"])


### PR DESCRIPTION
  - Update pytest-infrahouse to ~0.17 (from ~0.9) and infrahouse-core to ~0.17 (from ~0.14)
  - Integrate cleanup_ecs_task_definitions fixture to automatically clean up task definitions after tests
